### PR TITLE
dc-60: wrap long text 

### DIFF
--- a/src/app/extensions/status-cell-renderer/status-cell-renderer.component.ts
+++ b/src/app/extensions/status-cell-renderer/status-cell-renderer.component.ts
@@ -24,7 +24,7 @@ import {MatTooltipModule} from "@angular/material/tooltip";
       </button>
       <button mat-button *ngIf="!released"
                 disabled
-                matTooltip="Available {{releaseText}}">
+                matTooltip="{{releaseText}}">
         <mat-icon>watch</mat-icon>
         {{releaseText}}
       </button>

--- a/src/app/services/grid-utils.service.ts
+++ b/src/app/services/grid-utils.service.ts
@@ -19,6 +19,8 @@ export class GridUtilsService {
     resizable: true,
     menuTabs: ["filterMenuTab", "generalMenuTab", "columnsMenuTab"],
     initialHide: true,
+    wrapText: true,
+    autoHeight:true,
   };
 
 
@@ -65,7 +67,7 @@ export class GridUtilsService {
     {field: "sharing_mechanism_with_DRACC"},
     {field: "comments"},
     {field: "production"},
-    {field: "status", hide: false, cellRenderer: StatusCellRendererComponent}
+    {field: "status", hide: false, cellRenderer: StatusCellRendererComponent, autoHeight:false, wrapText:false}
   ];
 
   public static readonly FACET_DEFINITIONS: FacetDef[] = [


### PR DESCRIPTION
#60 wrap long texts for all columns, status column did not look good when wrapping , so excluded status alone.